### PR TITLE
renamed TPR to CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Package crdstorage implements the microstorage interface to provide storage
 primitives based on Kubernetes CRDs. The [microstorage][microstorage]
 implementation using Kubernetes third-party-objects as its backend.
 
-[microstorage]: https://github.com/giantswarm/microstorage
+[microstorage]: https://github.com/giantswarm/microstorage/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/tprstorage.svg?style=shield)](https://circleci.com/gh/giantswarm/tprstorage)
+[![CircleCI](https://circleci.com/gh/giantswarm/crdstorage.svg?style=shield)](https://circleci.com/gh/giantswarm/crdstorage)
 
-# tprstorage
+# crdstorage
 
-The [microstorage][microstorage] implementation using Kubernetes
-third-party-objects as its backend.
+Package crdstorage implements the microstorage interface to provide storage
+primitives based on Kubernetes CRDs. The [microstorage][microstorage]
+implementation using Kubernetes third-party-objects as its backend.
 
-[microstorage]: https://github.com/giantswarm/microstorage/
+[microstorage]: https://github.com/giantswarm/microstorage

--- a/custom_object.go
+++ b/custom_object.go
@@ -1,10 +1,10 @@
-package tprstorage
+package crdstorage
 
 import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// customObject represents the tprstorage TPR's custom object. It holds the
+// customObject represents the crdstorage CRD's custom object. It holds the
 // storage data.
 type customObject struct {
 	apismetav1.TypeMeta   `json:",inline"`

--- a/error.go
+++ b/error.go
@@ -1,4 +1,4 @@
-package tprstorage
+package crdstorage
 
 import (
 	"github.com/giantswarm/microerror"

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/giantswarm/tprstorage
+package: github.com/giantswarm/crdstorage
 import:
 - package: github.com/giantswarm/microerror
   version: master

--- a/storage_integration_test.go
+++ b/storage_integration_test.go
@@ -1,6 +1,6 @@
 // +build integration
 
-package tprstorage
+package crdstorage
 
 /*
 	Usage:

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,4 +1,4 @@
-package tprstorage
+package crdstorage
 
 import (
 	"testing"


### PR DESCRIPTION
Here I want to get renaming sorted and make the CI build. Note that the TPR implementation is still used under the hood. I will sort this in the next steps. 

```
$ go test -tags=integration .
ok  	github.com/giantswarm/crdstorage	26.777s
```
```
$ go test ./...
ok  	github.com/giantswarm/crdstorage	0.101s