### PR TITLE
initialize map if nil to prevent assignmend on nil map

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -237,6 +237,10 @@ func (s *Storage) Put(ctx context.Context, kv microstorage.KV) error {
 		return microerror.Mask(err)
 	}
 
+	if storageConfig.Spec.Storage.Data == nil {
+		storageConfig.Spec.Storage.Data = map[string]string{}
+	}
+
 	storageConfig.Spec.Storage.Data[kv.Key()] = kv.Val()
 
 	_, err = s.g8sClient.CoreV1alpha1().StorageConfigs(s.namespace.Name).Update(storageConfig)


### PR DESCRIPTION
On `gorgoth` we ended up in a situation where the storageconfig state was like this. 

```
spec:
  storage: {}
```

I do not know how we got into this situation but it should at least look like this. 

```
spec:
  storage:
    data:
```

This PR here fixes the problem but I do not see a nice way to test this reliably. 