### PR TITLE
Rename *k8scrdclient.CRDClient -> k8scrdclient.Interface

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Config struct {
-	CRDClient *k8scrdclient.CRDClient
+	CRDClient k8scrdclient.Interface
 	G8sClient versioned.Interface
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
@@ -30,7 +30,7 @@ type Config struct {
 }
 
 type Storage struct {
-	crdClient *k8scrdclient.CRDClient
+	crdClient k8scrdclient.Interface
 	g8sClient versioned.Interface
 	k8sClient kubernetes.Interface
 	logger    micrologger.Logger


### PR DESCRIPTION
k8scrdclient was recently refactored to be under k8sclient and at the
same time it got an interface to hide the implementation. Use the
interface in order to be compatible with k8sclient.CRDClient().

Needed for Cluster API type upgrade in `api`: https://github.com/giantswarm/api/pull/961